### PR TITLE
Enable use of stylesheet formatter

### DIFF
--- a/lib/css.js
+++ b/lib/css.js
@@ -33,5 +33,5 @@ export function parse(abbr, options) {
 		abbr = parseAbbreviation(abbr);
 	}
 
-	return abbr.use(resolveSnippets, options.snippets);
+	return abbr.use(resolveSnippets, options.snippets, options.format ? options.format.stylesheet : {});
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@emmetio/abbreviation": "^0.6.1",
     "@emmetio/css-abbreviation": "^0.3.1",
-    "@emmetio/css-snippets-resolver": "^0.2.5",
+    "@emmetio/css-snippets-resolver": "^0.2.6",
     "@emmetio/html-snippets-resolver": "^0.1.4",
     "@emmetio/html-transform": "^0.3.2",
     "@emmetio/lorem": "^1.0.1",
@@ -15,7 +15,7 @@
     "@emmetio/output-profile": "^0.1.5",
     "@emmetio/snippets": "^0.2.3",
     "@emmetio/snippets-registry": "^0.3.1",
-    "@emmetio/stylesheet-formatters": "^0.1.2",
+    "@emmetio/stylesheet-formatters": "^0.1.3",
     "@emmetio/variable-resolver": "^0.2.1"
   },
   "devDependencies": {

--- a/test/css.js
+++ b/test/css.js
@@ -29,4 +29,26 @@ describe('CSS expand', () => {
 	it('chains', () => {
 		assert.equal(expand('p.5+m-a'), 'padding: 0.5em;\nmargin: auto;');
 	});
+
+	it('formatter options', () => {
+		let options = {
+			format: {
+				stylesheet: {
+					between: "::",
+					after: ";;",
+					intUnit: 'pt',
+					floatUnit: 'vh',
+					unitAliases: {
+						e :'em',
+						p: '%',
+						x: 'ex',
+						r: ' / @rem'
+					}
+				}
+			}
+		};
+		assert.equal(expand('p10', options), 'padding::10pt;;');
+		assert.equal(expand('p10.2', options), 'padding::10.2vh;;');
+		assert.equal(expand('p10r', options), 'padding::10 / @rem;;');
+	});
 });


### PR DESCRIPTION
This PR enables the use of changes done in https://github.com/emmetio/stylesheet-formatters/pull/2 and https://github.com/emmetio/css-snippets-resolver/pull/1 which is to allow customization using the stylesheet formatter

cc @sergeche